### PR TITLE
Configurable cache size for processing validations

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/cfg/ValidationConfiguration.java
+++ b/src/main/java/com/github/fge/jsonschema/cfg/ValidationConfiguration.java
@@ -70,6 +70,11 @@ public final class ValidationConfiguration
      * Whether to use {@code format} in the resulting factory
      */
     final boolean useFormat;
+    
+    /**
+     * Cache size for processing validations
+     */
+    final int cacheSize;
 
     /**
      * The set of syntax messages
@@ -113,6 +118,7 @@ public final class ValidationConfiguration
         libraries = ImmutableMap.copyOf(builder.libraries);
         defaultLibrary = builder.defaultLibrary;
         useFormat = builder.useFormat;
+        cacheSize = builder.cacheSize;
         syntaxMessages = builder.syntaxMessages;
         validationMessages = builder.validationMessages;
     }
@@ -145,6 +151,11 @@ public final class ValidationConfiguration
     public boolean getUseFormat()
     {
         return useFormat;
+    }
+    
+    public int getCacheSize()
+    {
+    	return cacheSize;
     }
 
     public MessageBundle getSyntaxMessages()

--- a/src/main/java/com/github/fge/jsonschema/cfg/ValidationConfigurationBuilder.java
+++ b/src/main/java/com/github/fge/jsonschema/cfg/ValidationConfigurationBuilder.java
@@ -82,9 +82,9 @@ public final class ValidationConfigurationBuilder
     boolean useFormat = true;
     
     /**
-     * Cache maximum size of 4096 records by default
+     * Cache maximum size of 512 records by default
      */
-    int cacheSize = 4096;
+    int cacheSize = 512;
 
     /**
      * The set of syntax messages

--- a/src/main/java/com/github/fge/jsonschema/cfg/ValidationConfigurationBuilder.java
+++ b/src/main/java/com/github/fge/jsonschema/cfg/ValidationConfigurationBuilder.java
@@ -80,6 +80,11 @@ public final class ValidationConfigurationBuilder
      * Whether to use {@code format} ({@code true} by default)
      */
     boolean useFormat = true;
+    
+    /**
+     * Cache maximum size of 4096 records by default
+     */
+    int cacheSize = 4096;
 
     /**
      * The set of syntax messages
@@ -119,6 +124,7 @@ public final class ValidationConfigurationBuilder
         libraries = Maps.newHashMap(cfg.libraries);
         defaultLibrary = cfg.defaultLibrary;
         useFormat = cfg.useFormat;
+        cacheSize = cfg.cacheSize;
         syntaxMessages = cfg.syntaxMessages;
         validationMessages = cfg.validationMessages;
     }
@@ -214,6 +220,14 @@ public final class ValidationConfigurationBuilder
     {
         BUNDLE.checkNotNull(validationMessages, "nullMessageBundle");
         this.validationMessages = validationMessages;
+        return this;
+    }
+
+    public ValidationConfigurationBuilder setCacheSize(
+            final int cacheSize)
+    {
+        BUNDLE.checkArgument(cacheSize >= -1, "invalidCacheSize");
+        this.cacheSize = cacheSize;
         return this;
     }
 

--- a/src/main/java/com/github/fge/jsonschema/main/JsonSchemaFactory.java
+++ b/src/main/java/com/github/fge/jsonschema/main/JsonSchemaFactory.java
@@ -275,6 +275,6 @@ public final class JsonSchemaFactory
         final Processor<SchemaContext, ValidatorList> processor
             = map.getProcessor();
         return new CachingProcessor<SchemaContext, ValidatorList>(processor,
-            SchemaContextEquivalence.getInstance());
+            SchemaContextEquivalence.getInstance(), validationCfg.getCacheSize());
     }
 }

--- a/src/main/java/com/github/fge/jsonschema/processors/validation/ValidationChain.java
+++ b/src/main/java/com/github/fge/jsonschema/processors/validation/ValidationChain.java
@@ -71,7 +71,7 @@ public final class ValidationChain
             = ProcessorChain.startWith(refResolver).chainWith(syntaxProcessor);
 
         resolver = new CachingProcessor<ValueHolder<SchemaTree>, ValueHolder<SchemaTree>>(
-            chain1.getProcessor(), SchemaHolderEquivalence.INSTANCE
+            chain1.getProcessor(), SchemaHolderEquivalence.INSTANCE, cfg.getCacheSize()
         );
 
         final SchemaDigester digester = new SchemaDigester(library);
@@ -86,7 +86,7 @@ public final class ValidationChain
         }
 
         builder = new CachingProcessor<SchemaContext, ValidatorList>(
-            chain2.getProcessor(), SchemaContextEquivalence.getInstance()
+            chain2.getProcessor(), SchemaContextEquivalence.getInstance(), cfg.getCacheSize()
         );
     }
 

--- a/src/main/resources/com/github/fge/jsonschema/validator/configuration.properties
+++ b/src/main/resources/com/github/fge/jsonschema/validator/configuration.properties
@@ -37,3 +37,4 @@ nullFormat = format attribute name cannot be null
 nullAttribute = attempt to register null implementation of format attribute "%s"
 nullKeyword = attempt to add null keyword to library
 nullType = null type argument to digester constructor
+invalidCacheSize = cache size must be greater than -1. -1 value sets a cache with unlimited records, zero-value disables the cache

--- a/src/test/java/com/github/fge/jsonschema/cfg/ValidationConfigurationTest.java
+++ b/src/test/java/com/github/fge/jsonschema/cfg/ValidationConfigurationTest.java
@@ -104,6 +104,18 @@ public final class ValidationConfigurationTest
     }
 
     @Test
+    public void cannotPutInvalidCacheSize()
+    {
+        try {
+            cfg.setCacheSize(-2);
+            fail("No exception thrown!!");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(),
+                BUNDLE.getMessage("invalidCacheSize"));
+        }
+    }
+
+    @Test
     public void defaultLibraryIsDraftV4()
     {
         final ValidationConfiguration defaultConfiguration


### PR DESCRIPTION
It'd be nice to set the cache size in source code when processing validations
